### PR TITLE
Fix resource format

### DIFF
--- a/src/thumbnailFactory.js
+++ b/src/thumbnailFactory.js
@@ -14,7 +14,7 @@ var getResourceFormat = function(mimeType) {
   case('image/gif'):
     return 'gif';
   default:
-    throw(imageFormatError);
+    return 'jpg';
   }
 };
 


### PR DESCRIPTION
This PR fixes an issue with malformed manifests, that don't include the `format` property in the image resources - we can assume, that `jpg` is supported, see [here](http://iiif.io/api/image/2.1/compliance/#format).

E.g. all of the **BnF** manifests in the demo aren't working anymore caused by this reason:
* http://gallica.bnf.fr/iiif/ark:/12148/btv1b84539771/manifest.json
* http://gallica.bnf.fr/iiif/ark:/12148/btv1b10500687r/manifest.json
* http://gallica.bnf.fr/iiif/ark:/12148/btv1b55002605w/manifest.json
* http://gallica.bnf.fr/iiif/ark:/12148/btv1b55002481n/manifest.json